### PR TITLE
Allow multiple visjs_components to coexist

### DIFF
--- a/examples/combined.py
+++ b/examples/combined.py
@@ -1,0 +1,142 @@
+from visjs_component import visjs
+import streamlit as st
+from math import sin, cos
+import numpy as np
+
+
+st.set_page_config(layout="wide")
+c1, c2, c3 = st.columns(3)
+
+
+with c1:
+    def custom(x, y):
+        return (sin(x/50) * cos(y/50) * 50 + 50)
+
+    graphData = []
+    steps = 50
+    axisMax = 314
+    axisStep = axisMax / steps
+
+    # python for cycle with step
+    for x in np.arange(0, axisMax, axisStep):
+        for y in np.arange(0, axisMax, axisStep):
+            value = custom(x, y)
+            graphData.append({
+                "x": x,
+                "y": y,
+                "z": value,
+                "style": value
+            })
+
+    data = {
+        "data": graphData,
+        "options": {
+            "width": "400px",
+            "height": "400px",
+            "style": "surface",
+            "showPerspective": True,
+            "showGrid": True,
+            "keepAspectRatio": True,
+            "verticalRatio": 0.5
+        }
+    }
+
+    def handler1(eventData):
+        st.session_state["output1"] = eventData['data']
+
+    eventHandlers = [
+        {
+            "event": "cameraPositionChange",
+            "callback": handler1,
+        }
+    ]
+
+    visjs(title="# Graph3d Vis", type="graph3d", data=data, eventHandlers=eventHandlers, key="v1")
+    st.header("Output")
+    if "output1" in st.session_state:
+        st.json(st.session_state.get("output1"))
+    else:
+        st.write("Waiting for event")
+
+
+with c2:
+    data = {
+        "nodes": [
+            {"id": 1, "label": "Node 1"},
+            {"id": 2, "label": "Node 2"},
+            {"id": 3, "label": "Node 3"},
+            {"id": 4, "label": "Node 4"},
+            {"id": 5, "label": "Node 5"},
+        ],
+        "edges": [
+            {"from": 1, "to": 3},
+            {"from": 1, "to": 2},
+            {"from": 2, "to": 4},
+            {"from": 2, "to": 5},
+        ],
+        "options": {
+            "nodes": {
+                "shape": "dot",
+                "size": 16,
+            },
+            "edges": {
+                "color": "#000000",
+            },
+            "physics": {
+                "enabled": True,
+            },
+            "interaction": {
+                "hover": True,
+            },
+            "height": "500px",
+        },
+    }
+
+    def handler2(eventData):
+        st.session_state["output2"] = eventData['data']
+
+    eventHandlers = [
+        {
+            "event": "click",
+            "callback": handler2,
+        }
+    ]
+
+    visjs(title="# Network Vis", type="network", data=data, eventHandlers=eventHandlers, key="v2")
+    st.header("Output")
+    if "output2" in st.session_state:
+        st.json(st.session_state.get("output2"))
+    else:
+        st.write("Waiting for event")
+
+
+with c3:
+    data = {
+        "items": [
+            {"id": 1, "content": "item 1", "start": "2013-04-20"},
+            {"id": 2, "content": "item 2", "start": "2013-04-14"},
+            {"id": 3, "content": "item 3", "start": "2013-04-18"},
+            {"id": 4, "content": "item 4", "start": "2013-04-16", "end": "2013-04-19"},
+            {"id": 5, "content": "item 5", "start": "2013-04-25"},
+            {"id": 6, "content": "item 6", "start": "2013-04-27"},
+        ],
+        "options": {}
+    }
+
+
+    def handler3(eventData):
+        st.session_state["output3"] = eventData['data']
+
+    eventHandlers = [
+        {
+            "event": "click",
+            "callback": handler3,
+        }
+    ]
+
+    visjs(title="# Timeline Vis", type="timeline", data=data, eventHandlers=eventHandlers, key="v3")
+    st.header("Output")
+    if "output3" in st.session_state:
+        st.json(st.session_state.get("output3"))
+    else:
+        st.write("Waiting for event")

--- a/src/visjs_component/__init__.py
+++ b/src/visjs_component/__init__.py
@@ -1,6 +1,6 @@
-from pathlib import Path
-from typing import Optional, Callable
 import json
+from pathlib import Path
+from typing import Optional, Callable, List, Dict
 
 import streamlit as st
 import streamlit.components.v1 as components
@@ -14,9 +14,9 @@ _component_func = components.declare_component(
 
 # Create the python function that will be called
 def visjs_component(
-    type: [str] = "network",
-    data: dict = {},
-    eventNames: list = [],
+    type: str = "network",
+    data: Dict = {},
+    eventNames: List = [],
     key: Optional[str] = None,
 ):
     """
@@ -29,25 +29,26 @@ def visjs_component(
         key=key,
     )
 
-    # print(component_value)
+    #print(component_value)
 
     return component_value
 
 
 def visjs(
-    title: [str] = "Data Vis",
-    type: [str] = "network",
-    data: [dict] = {},
-    eventHandlers: [list] = [],
+    title: Optional[str] = None,
+    type: str = "network",
+    data: Dict = {},
+    eventHandlers: List = [],
+    key: str = None,
 ):
-    st.set_page_config(layout="wide")
-    st.write(title)
+    if title:
+        st.write(title)
 
     eventNames = []
     for eventHandler in eventHandlers:
         eventNames.append(eventHandler["event"])
 
-    value = visjs_component(type=type, data=data, eventNames=eventNames)
+    value = visjs_component(type=type, data=data, eventNames=eventNames, key=key)
 
     if eventHandlers:
         if value is not None:
@@ -56,37 +57,3 @@ def visjs(
             for eventHandler in eventHandlers:
                 if eventHandler["event"] == eventData['event']:
                     eventHandler["callback"](eventData)
-
-
-# if __name__ == "__main__":
-#     main(title="# Data Vis", type="network", data={
-#         "nodes": [
-#             {"id": 1, "label": 'Node 1'},
-#             {"id": 2, "label": 'Node 2'},
-#             {"id": 3, "label": 'Node 3'},
-#             {"id": 4, "label": 'Node 4'},
-#             {"id": 5, "label": 'Node 5'}
-#         ],
-#         "edges": [
-#             {"from": 1, "to": 3},
-#             {"from": 1, "to": 2},
-#             {"from": 2, "to": 4},
-#             {"from": 2, "to": 5}
-#         ],
-#         "options": {
-#             "nodes": {
-#                 "shape": "dot",
-#                 "size": 16,
-#             },
-#             "edges": {
-#                 "color": "#000000",
-#             },
-#             "physics": {
-#                 "enabled": True,
-#             },
-#             "interaction": {
-#                 "hover": True,
-#             },
-#             "height": "500px",
-#         }
-#     })


### PR DESCRIPTION
I added key arguments to allow multiple instances of visjs-component on a single streamlit page without conflict.

I also removed st.set_page_config from visjs because it can only be called once.

I also made an new example combined.py that shows the three types at once.

Finally, there are a few minor corrections to type annotations.